### PR TITLE
Fix lightform user requiring password for sudo commands

### DIFF
--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -125,6 +125,15 @@ async function performBootstrapSteps(
     logger.verboseLog(`Warning: ${String(error).slice(0, 50)}...`);
   }
 
+  // Configure passwordless sudo for lightform user
+  try {
+    await sshClient.exec(`echo "${targetUsername} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${targetUsername}`);
+    await sshClient.exec(`chmod 440 /etc/sudoers.d/${targetUsername}`);
+    logger.verboseLog("→ Configured passwordless sudo access");
+  } catch (error) {
+    logger.verboseLog(`Warning configuring sudo: ${String(error).slice(0, 50)}...`);
+  }
+
   logger.serverStep("Installing Docker");
 
   // Check if Docker already installed


### PR DESCRIPTION
## Summary
- Configures passwordless sudo access for lightform user during server bootstrap
- Creates `/etc/sudoers.d/lightform` with `NOPASSWD: ALL` option  
- Sets proper file permissions (440) for security
- Enables automated operations that require elevated privileges

## Test plan
- [ ] Test fresh server bootstrap to verify sudoers file is created correctly
- [ ] Verify lightform user can run sudo commands without password prompts
- [ ] Confirm file permissions are set correctly (440)

Resolves #46

🤖 Generated with [Claude Code](https://claude.ai/code)