### PR TITLE
Add reserved names validation to prevent CLI command conflicts

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -14,8 +14,8 @@
 ```bash
 cd examples/basic  # or examples/nextjs
 
-# Deploy with force flag (setup is automatic)
-bun ../../packages/cli/src/index.ts --force
+# Deploy (setup is automatic)
+bun ../../packages/cli/src/index.ts
 
 # Enable staging mode immediately after first deployment
 ssh lightform@157.180.47.213 "docker exec lightform-proxy /usr/local/bin/lightform-proxy set-staging --enabled true"
@@ -164,7 +164,7 @@ When troubleshooting Lightform issues, follow this systematic feedback loop:
 ```bash
 # 1. Test deploy (setup is automatic)
 cd examples/basic
-bun ../../packages/cli/src/index.ts --force --verbose
+bun ../../packages/cli/src/index.ts --verbose
 
 # 2. Check the logs
 ssh lightform@157.180.47.213 "docker logs --tail 50 lightform-proxy"
@@ -182,7 +182,7 @@ ssh lightform@157.180.47.213 "docker logs --tail 30 gmail-web"
 
 # 5. Redeploy
 cd packages/proxy && ./publish.sh && cd ../../examples/basic  # If proxy changes
-bun ../../packages/cli/src/index.ts --force --verbose         # Deploy (auto-setup included)
+bun ../../packages/cli/src/index.ts --verbose                   # Deploy (auto-setup included)
 
 # 6. Start over
 # Go back to step 2 and check logs again

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -122,6 +122,9 @@ function showCommandHelp(command: string): void {
         "  - Commit git changes before deploying"
       );
       console.log("  - Requires Docker running locally for image builds");
+      console.log(
+        "  - App/service names cannot be: init, status, proxy (reserved)"
+      );
       break;
 
     case "status":

--- a/packages/cli/tests/reserved-names.test.ts
+++ b/packages/cli/tests/reserved-names.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect } from "bun:test";
+import { validateConfig, ConfigValidationError } from "../src/utils/config-validator";
+import { LightformConfig } from "../src/config/types";
+
+describe("Reserved Names Validation", () => {
+  test("should reject app with reserved name 'proxy'", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        proxy: {
+          image: "test/proxy",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    expect(errors).toHaveLength(1);
+    expect(errors[0].type).toBe("reserved_name");
+    expect(errors[0].message).toContain("proxy");
+    expect(errors[0].message).toContain("reserved");
+    expect(errors[0].entries).toEqual(["proxy"]);
+    expect(errors[0].suggestions).toBeDefined();
+    expect(errors[0].suggestions?.some(s => s.includes("proxy-app"))).toBe(true);
+  });
+
+  test("should reject service with reserved name 'status'", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      services: {
+        status: {
+          image: "test/status",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    expect(errors).toHaveLength(1);
+    expect(errors[0].type).toBe("reserved_name");
+    expect(errors[0].message).toContain("status");
+    expect(errors[0].entries).toEqual(["status"]);
+  });
+
+  test("should reject app with reserved name 'init'", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        init: {
+          image: "test/init",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    expect(errors).toHaveLength(1);
+    expect(errors[0].type).toBe("reserved_name");
+    expect(errors[0].message).toContain("init");
+  });
+
+  test("should reject multiple reserved names", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        proxy: {
+          image: "test/proxy",
+          server: "test.com",
+        },
+        init: {
+          image: "test/init", 
+          server: "test.com",
+        },
+      },
+      services: {
+        status: {
+          image: "test/status",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    expect(errors).toHaveLength(3);
+    expect(errors.map(e => e.entries[0]).sort()).toEqual(["init", "proxy", "status"]);
+    expect(errors.every(e => e.type === "reserved_name")).toBe(true);
+  });
+
+  test("should allow non-reserved names", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        web: {
+          image: "test/web",
+          server: "test.com",
+        },
+        api: {
+          image: "test/api",
+          server: "test.com",
+        },
+      },
+      services: {
+        database: {
+          image: "postgres:15",
+          server: "test.com",
+        },
+        redis: {
+          image: "redis:alpine",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    // Should not have any reserved name errors
+    const reservedNameErrors = errors.filter(e => e.type === "reserved_name");
+    expect(reservedNameErrors).toHaveLength(0);
+  });
+
+  test("should allow names similar to reserved names", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        "proxy-app": {
+          image: "test/proxy-app",
+          server: "test.com",
+        },
+        "web-proxy": {
+          image: "test/web-proxy",
+          server: "test.com",
+        },
+        "status-checker": {
+          image: "test/status-checker",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    // Should not have any reserved name errors
+    const reservedNameErrors = errors.filter(e => e.type === "reserved_name");
+    expect(reservedNameErrors).toHaveLength(0);
+  });
+
+  test("should work with array format configuration", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: [
+        {
+          name: "proxy",
+          image: "test/proxy",
+          server: "test.com",
+        },
+      ],
+      services: [
+        {
+          name: "status",
+          image: "test/status",
+          server: "test.com",
+        },
+      ],
+    };
+
+    const errors = validateConfig(config);
+    
+    const reservedNameErrors = errors.filter(e => e.type === "reserved_name");
+    expect(reservedNameErrors).toHaveLength(2);
+    expect(reservedNameErrors.map(e => e.entries[0]).sort()).toEqual(["proxy", "status"]);
+  });
+
+  test("should include helpful suggestions", () => {
+    const config: LightformConfig = {
+      name: "test-project",
+      apps: {
+        proxy: {
+          image: "test/proxy",
+          server: "test.com",
+        },
+      },
+    };
+
+    const errors = validateConfig(config);
+    
+    expect(errors).toHaveLength(1);
+    const suggestions = errors[0].suggestions || [];
+    
+    // Check that suggestions contain helpful alternatives
+    expect(suggestions.some(s => s.includes("proxy-app"))).toBe(true);
+    expect(suggestions.some(s => s.includes("proxy-service"))).toBe(true);
+    expect(suggestions.some(s => s.includes("web-proxy"))).toBe(true);
+    expect(suggestions.some(s => s.includes("Reserved names:"))).toBe(true);
+    expect(suggestions.some(s => s.includes("init, status, proxy"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add validation to reject app/service names that conflict with CLI commands (`init`, `status`, `proxy`)
- Include helpful error messages with suggested alternatives like `proxy-app`, `web-proxy`, etc.
- Add comprehensive tests for reserved names validation covering all scenarios
- Update help text to mention reserved names restriction

## Problem Solved
Fixes the naming conflict issue identified in #52 where users couldn't reliably deploy apps named after CLI commands. For example:
- `lightform proxy` would run proxy management instead of deploying a "proxy" app
- `lightform status` would show status instead of deploying a "status" service

## Solution
Reserved names approach: CLI commands (`init`, `status`, `proxy`) are now reserved and cannot be used as app/service names. Users get clear validation errors with helpful suggestions.

## Test Plan
- [x] Comprehensive test suite covering all reserved names
- [x] Tests for both object and array config formats
- [x] Validation includes helpful suggestions for alternatives
- [x] CLI builds without TypeScript errors
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)